### PR TITLE
Wip/issue/422 autogenerate comments

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -534,6 +534,9 @@ def _render_column(column, autogen_context):
     if column.nullable is not None:
         opts.append(("nullable", column.nullable))
 
+    if column.comment is not None:
+        opts.append(("comment", "'%s'" % column.comment))
+
     # TODO: for non-ascii colname, assign a "key"
     return "%(prefix)sColumn(%(name)r, %(type)s, %(kw)s)" % {
         'prefix': _sqlalchemy_autogenerate_prefix(autogen_context),

--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -332,6 +332,7 @@ def _alter_column(autogen_context, op):
     server_default = op.modify_server_default
     type_ = op.modify_type
     nullable = op.modify_nullable
+    comment = op.modify_comment
     autoincrement = op.kw.get('autoincrement', None)
     existing_type = op.existing_type
     existing_nullable = op.existing_nullable
@@ -365,6 +366,9 @@ def _alter_column(autogen_context, op):
     if nullable is not None:
         text += ",\n%snullable=%r" % (
             indent, nullable,)
+    if comment is not None:
+        text += ",\n%scomment=%r" % (
+            indent, comment,)
     if nullable is None and existing_nullable is not None:
         text += ",\n%sexisting_nullable=%r" % (
             indent, existing_nullable)

--- a/alembic/ddl/base.py
+++ b/alembic/ddl/base.py
@@ -94,6 +94,12 @@ class DropColumn(AlterTable):
         self.column = column
 
 
+class ColumnComment(AlterColumn):
+    def __init__(self, name, column_name, comment, **kw):
+        super(ColumnComment, self).__init__(name, column_name, **kw)
+        self.comment = comment
+
+
 @compiles(RenameTable)
 def visit_rename_table(element, compiler, **kw):
     return "%s RENAME TO %s" % (
@@ -155,6 +161,11 @@ def visit_column_default(element, compiler, **kw):
         if element.default is not None
         else "DROP DEFAULT"
     )
+
+
+@compiles(ColumnComment)
+def visit_column_comment(element, compiler, **kw):
+    raise NotImplementedError('There is no COMMENT command in the SQL standard.')
 
 
 def quote_dotted(name, quote):

--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -124,6 +124,7 @@ class DefaultImpl(with_metaclass(ImplMeta)):
                      type_=None,
                      schema=None,
                      autoincrement=None,
+                     comment=None,
                      existing_type=None,
                      existing_server_default=None,
                      existing_nullable=None,
@@ -156,6 +157,19 @@ class DefaultImpl(with_metaclass(ImplMeta)):
                 existing_server_default=existing_server_default,
                 existing_nullable=existing_nullable,
             ))
+
+        # TODO (3)
+        if self.dialect.supports_comments and comment:
+            self._exec(
+                base.ColumnComment(
+                    table_name, column_name, comment,
+                    schema=schema,
+                    existing_type=existing_type,
+                    existing_server_default=existing_server_default,
+                    existing_nullable=existing_nullable,
+                )
+            )
+
         # do the new name last ;)
         if name is not None:
             self._exec(base.ColumnName(

--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -208,6 +208,15 @@ class DefaultImpl(with_metaclass(ImplMeta)):
         for index in table.indexes:
             self._exec(schema.CreateIndex(index))
 
+        if self.dialect.supports_comments:
+
+            if table.comment:
+                self._exec(schema.SetTableComment(table))
+
+            for column in table.columns:
+                if column.comment is not None:
+                    self.connection.execute(schema.SetColumnComment(column))
+
     def drop_table(self, table):
         self._exec(schema.DropTable(table))
 

--- a/alembic/ddl/postgresql.py
+++ b/alembic/ddl/postgresql.py
@@ -3,7 +3,7 @@ import re
 from ..util import compat
 from .. import util
 from .base import compiles, alter_column, alter_table, format_table_name, \
-    format_type, AlterColumn, RenameTable
+    format_type, AlterColumn, RenameTable, ColumnComment
 from .impl import DefaultImpl
 from sqlalchemy.dialects.postgresql import INTEGER, BIGINT
 from ..autogenerate import render
@@ -238,6 +238,21 @@ def visit_column_type(element, compiler, **kw):
         alter_column(compiler, element.column_name),
         "TYPE %s" % format_type(compiler, element.type_),
         "USING %s" % element.using if element.using else ""
+    )
+
+
+@compiles(ColumnComment, "postgresql")
+def visit_column_comment(element, compiler, **kw):
+    ddl = "COMMENT ON COLUMN {table_name}.{column_name} IS '{comment}'"
+    if element.comment is None:
+        comment = 'NULL'
+    else:
+        comment = element.comment
+
+    return ddl.format(
+        table_name=element.table_name,
+        column_name=element.column_name,
+        comment=comment
     )
 
 

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -1233,7 +1233,9 @@ class AlterColumnOp(AlterTableOp):
             existing_type=None,
             existing_server_default=False,
             existing_nullable=None,
+            existing_comment=None,
             modify_nullable=None,
+            modify_comment=None,
             modify_server_default=False,
             modify_name=None,
             modify_type=None,
@@ -1245,7 +1247,9 @@ class AlterColumnOp(AlterTableOp):
         self.existing_type = existing_type
         self.existing_server_default = existing_server_default
         self.existing_nullable = existing_nullable
+        self.existing_comment = existing_comment
         self.modify_nullable = modify_nullable
+        self.modify_comment = modify_comment
         self.modify_server_default = modify_server_default
         self.modify_name = modify_name
         self.modify_type = modify_type
@@ -1261,6 +1265,7 @@ class AlterColumnOp(AlterTableOp):
                  {
                      "existing_nullable": self.existing_nullable,
                      "existing_server_default": self.existing_server_default,
+                     "existing_comment": self.existing_comment
                  },
                  self.existing_type,
                  self.modify_type)
@@ -1271,7 +1276,8 @@ class AlterColumnOp(AlterTableOp):
                 ("modify_nullable", schema, tname, cname,
                     {
                         "existing_type": self.existing_type,
-                        "existing_server_default": self.existing_server_default
+                        "existing_server_default": self.existing_server_default,
+                        "existing_comment": self.existing_comment
                     },
                     self.existing_nullable,
                     self.modify_nullable)
@@ -1282,10 +1288,23 @@ class AlterColumnOp(AlterTableOp):
                 ("modify_default", schema, tname, cname,
                  {
                      "existing_nullable": self.existing_nullable,
-                     "existing_type": self.existing_type
+                     "existing_type": self.existing_type,
+                     "existing_comment": self.existing_comment
                  },
                  self.existing_server_default,
                  self.modify_server_default)
+            )
+
+        if self.modify_comment is not None:
+            col_diff.append(
+                ("modify_comment", schema, tname, cname,
+                 {
+                     "existing_nullable": self.existing_nullable,
+                     "existing_type": self.existing_type,
+                     "existing_server_default": self.existing_server_default,
+                 },
+                 self.existing_comment,
+                 self.modify_comment)
             )
 
         return col_diff
@@ -1293,7 +1312,8 @@ class AlterColumnOp(AlterTableOp):
     def has_changes(self):
         hc1 = self.modify_nullable is not None or \
             self.modify_server_default is not False or \
-            self.modify_type is not None
+            self.modify_type is not None or \
+            self.modify_comment is not None
         if hc1:
             return True
         for kw in self.kw:
@@ -1337,6 +1357,7 @@ class AlterColumnOp(AlterTableOp):
     def alter_column(
         cls, operations, table_name, column_name,
         nullable=None,
+        comment=None,
         server_default=False,
         new_column_name=None,
         type_=None,
@@ -1438,6 +1459,7 @@ class AlterColumnOp(AlterTableOp):
             modify_type=type_,
             modify_server_default=server_default,
             modify_nullable=nullable,
+            modify_comment=comment,
             **kw
         )
 
@@ -1447,6 +1469,7 @@ class AlterColumnOp(AlterTableOp):
     def batch_alter_column(
         cls, operations, column_name,
         nullable=None,
+        comment=None,
         server_default=False,
         new_column_name=None,
         type_=None,
@@ -1473,6 +1496,7 @@ class AlterColumnOp(AlterTableOp):
             modify_type=type_,
             modify_server_default=server_default,
             modify_nullable=nullable,
+            modify_comment=comment,
             **kw
         )
 

--- a/alembic/operations/toimpl.py
+++ b/alembic/operations/toimpl.py
@@ -22,6 +22,7 @@ def alter_column(operations, operation):
     server_default = operation.modify_server_default
     new_column_name = operation.modify_name
     nullable = operation.modify_nullable
+    comment = operation.modify_comment
 
     def _count_constraint(constraint):
         return not isinstance(
@@ -50,6 +51,7 @@ def alter_column(operations, operation):
         existing_type=existing_type,
         existing_server_default=existing_server_default,
         existing_nullable=existing_nullable,
+        comment=comment,
         **operation.kw
     )
 

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -943,7 +943,7 @@ class AutogenRenderTest(TestBase):
         eq_ignore_whitespace(
             autogenerate.render_op_text(self.autogen_context, op_obj),
             "op.add_column('foo', sa.Column('x', sa.Integer(), "
-            "server_default='5', nullable=True, comment='This is a Column'))"
+            "nullable=True, comment='This is a Column'))"
         )
 
     def test_render_add_column_w_schema(self):
@@ -1010,6 +1010,19 @@ class AutogenRenderTest(TestBase):
             'sa.Column(\'updated_at\', sa.TIMESTAMP(), '
             'server_default=\'TIMEZONE("utc", CURRENT_TIMESTAMP)\', '
             'nullable=False)'
+        )
+
+    def test_render_col_with_comment(self):
+        c = Column('some_key', Integer, comment='This is a comment')
+        Table('some_table', MetaData(), c)
+        result = autogenerate.render._render_column(
+            c, self.autogen_context
+        )
+        eq_ignore_whitespace(
+            result,
+            'sa.Column(\'some_key\', sa.Integer(), '
+            'nullable=True, '
+            'comment=\'This is a comment\')'
         )
 
     def test_render_col_autoinc_false_mysql(self):
@@ -1142,6 +1155,17 @@ class AutogenRenderTest(TestBase):
             "op.alter_column('sometable', 'somecolumn', "
             "existing_type=sa.BigInteger(), type_=sa.Integer(), "
             "autoincrement=True)"
+        )
+
+    def test_render_modify_comment(self):
+        op_obj = ops.AlterColumnOp(
+            "sometable", "somecolumn",
+            modify_comment="This is a comment"
+        )
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.alter_column('sometable', 'somecolumn', "
+            "comment='This is a comment')"
         )
 
     def test_render_fk_constraint_kwarg(self):

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -937,6 +937,15 @@ class AutogenRenderTest(TestBase):
             "server_default='5', nullable=True))"
         )
 
+    def test_render_add_column_with_comment(self):
+        op_obj = ops.AddColumnOp(
+            "foo", Column("x", Integer, comment="This is a Column"))
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.add_column('foo', sa.Column('x', sa.Integer(), "
+            "server_default='5', nullable=True, comment='This is a Column'))"
+        )
+
     def test_render_add_column_w_schema(self):
         op_obj = ops.AddColumnOp(
             "bar", Column("x", Integer, server_default="5"),

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -766,6 +766,18 @@ class OpTest(TestBase):
         eq_(t1.c.id.name, "id")
         eq_(t1.schema, "schema")
 
+    def test_create_table_emits_comment_ddl_for_supported_dialect(self):
+        context = op_fixture('postgresql')
+        op.create_table(
+            "some_table",
+            Column('id', Integer, primary_key=True),
+            Column('foo_id', Integer, ForeignKey('foo.id')),
+            comment='This is a table comment'
+        )
+        context.assert_contains(
+            "COMMENT ON TABLE some_table IS 'This is a table comment'"
+        )
+
     def test_create_table_no_pk(self):
         context = op_fixture()
         t1 = op.create_table(

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -415,6 +415,16 @@ class OpTest(TestBase):
             'ALTER TABLE foo.t ALTER COLUMN c SET NOT NULL'
         )
 
+    def test_alter_column_only_sets_comment_for_supported_dialects(self):
+        op_fixture()
+        with mock.patch('alembic.ddl.impl.base.ColumnComment') as mock_comment_ddl:
+            op.alter_column(
+                "t", "c", nullable=False, existing_type=Boolean(),
+                schema='foo', comment='This is a column comment'
+            )
+
+            mock_comment_ddl.assert_not_called()
+
     def test_add_foreign_key(self):
         context = op_fixture()
         op.create_foreign_key('fk_test', 't1', 't2',

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -136,6 +136,18 @@ class PostgresqlOpTest(TestBase):
             'USING gist ("SomeColumn" WITH >) WHERE ("SomeColumn" > 5)'
         )
 
+    def test_alter_column_only_sets_comment_for_postgresql(self):
+        context = op_fixture('postgresql')
+        op.alter_column(
+            "t", "c", nullable=False, existing_type=Boolean(),
+            schema='foo', comment='This is a column comment'
+        )
+
+        context.assert_(
+            "ALTER TABLE foo.t ALTER COLUMN c SET NOT NULL",
+            "COMMENT ON COLUMN t.c IS 'This is a column comment'"
+        )
+
 
 class PGOfflineEnumTest(TestBase):
 


### PR DESCRIPTION
(1) alembic/tests/test_op.py
:meth:`test_alter_column_only_sets_comment_for_supported_dialects`
This test case currently passes because we check for `self.dialects.supports.comments`
Should there be an explicit warning or error raised when comment is passed to an op. that
does nothing with it (IE SqlLite)

(2) alembic/alembic/ddl/postgresql.py
:func:`.visit_column_comment` Needs an explicit test for setting comment to NULL

(3) alembic/alembic/ddl/impl.py:162
I think i need to do something similar to existing_comment here.  For instance, postgres un sets
a column comment with the following syntax. `COMMENT ON table.column IS NULL`.  If the user explicitly
sets `op.alter_column('table', 'column', column=None)` should we issue the ColumnComment ddl as defined above?

(4) autogenerate for create_table op

(5) add_column op should handle comment?

(6) Explicit ops for add_table_comment add_column_comment